### PR TITLE
Get locale and date format from browser

### DIFF
--- a/components/UserLocale.tsx
+++ b/components/UserLocale.tsx
@@ -1,0 +1,15 @@
+import { useContext, useEffect, useState } from "preact/hooks";
+import { UserContext } from "../routes/_app.tsx"
+import DetectUserLocale from "../islands/DetectUserLocale.tsx";
+
+// This component wraps DetectUserLocale because context providers aren't
+// serialized to clients. Therefore we have to get the context in this
+// component and pass it to the island. Because the props we're passing
+// are signals, within the island those signals can be updated.
+export default function UserLocale() {
+  let { locale, timeZone } = useContext(UserContext);
+
+  return (
+    <DetectUserLocale locale={locale} timeZone={timeZone} />
+  );
+};

--- a/context/UserContext.ts
+++ b/context/UserContext.ts
@@ -1,0 +1,21 @@
+import { Signal, signal } from "@preact/signals";
+
+// User-specific configuration that comes from the browser, such as locale and
+// time zone information.
+// Matches the (destructured) output of Intl.DateTimeFormat().resolvedOptions().
+type UserDateTimeFormat = {
+  locale: Signal<string>;
+  timeZone: Signal<string>;
+};
+
+// Generate initial state with sane defaults.
+const createUserState = (): UserDateTimeFormat => {
+  const locale = signal<string>("en-US");
+  const timeZone = signal<string>("America/New_York");
+  return { locale, timeZone };
+};
+
+// Export the initial state itself, not the function.
+export default createUserState();
+
+export { UserDateTimeFormat };

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -20,6 +20,7 @@ import * as $14 from "./routes/role/add.tsx";
 import * as $15 from "./routes/roles.tsx";
 import * as $16 from "./routes/signout.ts";
 import * as $17 from "./routes/signup.tsx";
+import * as $$0 from "./islands/DetectUserLocale.tsx";
 
 const manifest = {
   routes: {
@@ -42,7 +43,9 @@ const manifest = {
     "./routes/signout.ts": $16,
     "./routes/signup.tsx": $17,
   },
-  islands: {},
+  islands: {
+    "./islands/DetectUserLocale.tsx": $$0,
+  },
   baseUrl: import.meta.url,
 };
 

--- a/islands/DetectUserLocale.tsx
+++ b/islands/DetectUserLocale.tsx
@@ -1,24 +1,17 @@
-import { useContext, useEffect, useState } from "preact/hooks";
-import { UserContext } from "../routes/_app.tsx"
+import { useEffect } from "preact/hooks";
 
 // Detect the user's locale and date formatting options and set the
 // resulting object as a signal value we can use in other components.
-export default function DetectUserLocale() {
-  const [browserDateTimeFormat, setBrowserDateTimeFormat] = useState({});
-
-  let { locale, timeZone } = useContext(UserContext);
-  console.log("OUTSIDE EFFECT locale", locale.value);
-
-	useEffect(() => {
-    console.log("INSIDE EFFECT locale: ", locale); // "undefined" in browser console
-	  setBrowserDateTimeFormat(Intl.DateTimeFormat().resolvedOptions());
-    locale.value = browserDateTimeFormat.locale;
-    timeZone.value = browserDateTimeFormat.timeZone;
-    console.log(timeZone)
+export default function DetectUserLocale({ locale, timeZone }) {
+  useEffect(() => {
+    // Alias the destructured properties to avoid collisons.
+    const { locale: browserLocale, timeZone: browserTimeZone } = Intl
+      .DateTimeFormat().resolvedOptions();
+    // Update the relevant signals.
+    locale.value = browserLocale;
+    timeZone.value = browserTimeZone;
   }, []);
 
   // Nothing to see here. Writing this return for completeness.
-  return (
-    <></>
-  );
-};
+  return <></>;
+}

--- a/islands/DetectUserLocale.tsx
+++ b/islands/DetectUserLocale.tsx
@@ -1,0 +1,24 @@
+import { useContext, useEffect, useState } from "preact/hooks";
+import { UserContext } from "../routes/_app.tsx"
+
+// Detect the user's locale and date formatting options and set the
+// resulting object as a signal value we can use in other components.
+export default function DetectUserLocale() {
+  const [browserDateTimeFormat, setBrowserDateTimeFormat] = useState({});
+
+  let { locale, timeZone } = useContext(UserContext);
+  console.log("OUTSIDE EFFECT locale", locale.value);
+
+	useEffect(() => {
+    console.log("INSIDE EFFECT locale: ", locale); // "undefined" in browser console
+	  setBrowserDateTimeFormat(Intl.DateTimeFormat().resolvedOptions());
+    locale.value = browserDateTimeFormat.locale;
+    timeZone.value = browserDateTimeFormat.timeZone;
+    console.log(timeZone)
+  }, []);
+
+  // Nothing to see here. Writing this return for completeness.
+  return (
+    <></>
+  );
+};

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,9 +1,14 @@
+import { createContext } from "preact";
 // asset() will automate adding cache headers to static assets.
 import { asset, Head } from "$fresh/runtime.ts";
 import { AppContext } from "$fresh/server.ts";
 import Header from "../components/Header.tsx";
 import { isAuthenticated } from "../lib/utils.ts";
 import GoogleAnalytics from "../components/GoogleAnalytics.tsx";
+import userState, { UserDateTimeFormat } from "../context/UserContext.ts"
+// Export this so we can expose it as a singleton for later useContext() calls.
+export const UserContext = createContext<UserDateTimeFormat>({} as UserDateTimeFormat)
+import DetectUserLocale from "../islands/DetectUserLocale.tsx";
 
 export default async function App(_req: Request, ctx: AppContext) {
   const isAuthned = isAuthenticated(ctx);
@@ -21,7 +26,10 @@ export default async function App(_req: Request, ctx: AppContext) {
           <div class="text-lg">
             <div class="flex flex-col min-h-screen mx-auto max-w-7xl w-full">
               <Header isAuthenticated={isAuthned} />
+              <UserContext.Provider value={userState}>
+              <DetectUserLocale />
               <ctx.Component />
+              </UserContext.Provider>
               {/* Future footer */}
             </div>
           </div>

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -8,7 +8,7 @@ import GoogleAnalytics from "../components/GoogleAnalytics.tsx";
 import userState, { UserDateTimeFormat } from "../context/UserContext.ts"
 // Export this so we can expose it as a singleton for later useContext() calls.
 export const UserContext = createContext<UserDateTimeFormat>({} as UserDateTimeFormat)
-import DetectUserLocale from "../islands/DetectUserLocale.tsx";
+import UserLocale from "../components/UserLocale.tsx";
 
 export default async function App(_req: Request, ctx: AppContext) {
   const isAuthned = isAuthenticated(ctx);
@@ -27,7 +27,7 @@ export default async function App(_req: Request, ctx: AppContext) {
             <div class="flex flex-col min-h-screen mx-auto max-w-7xl w-full">
               <Header isAuthenticated={isAuthned} />
               <UserContext.Provider value={userState}>
-              <DetectUserLocale />
+              <UserLocale />
               <ctx.Component />
               </UserContext.Provider>
               {/* Future footer */}


### PR DESCRIPTION
- Ships an island component that queries the browser for this information.
- Wraps the island in a server component so that we can pass context as props and update the constituent information (which are signals).
  - We use a parent component here because context providers are not serialized for client-facing code.
  - See my Discord convo at https://discord.com/channels/684898665143206084/991511118524715139/1146507493992825042
  - Known issue: https://github.com/denoland/fresh/issues/983